### PR TITLE
Add a Identity Provider service (`idP`)

### DIFF
--- a/authentication.js
+++ b/authentication.js
@@ -31,9 +31,7 @@ const auth = (options) => {
 				ok: false,
 				msg: 'user not found',
 			};
-		}
-
-		if (
+		} else if (
 			requirePassword &&
 			!(await bcrypt.compare(password, users[username].passwordHash))
 		) {

--- a/authentication.js
+++ b/authentication.js
@@ -42,14 +42,14 @@ const auth = (options) => {
 		}
 
 		if (!state.ok) {
-			if (options.callback) await options.callback(req, username, state);
+			if (options?.callback) await options.callback(req, username, state);
 			return res.json(state);
 		}
 
 		req.user = username;
 		req.stead = users[username].stead;
 
-		if (options.callback) await options.callback(req, username, state);
+		if (options?.callback) await options.callback(req, username, state);
 
 		next();
 	};

--- a/authentication.js
+++ b/authentication.js
@@ -1,0 +1,59 @@
+import bcrypt from 'bcrypt';
+import { users } from './main.js';
+
+const auth = (options) => {
+	const requirePassword = options?.requirePassword == false ? false : true;
+
+	return async (req, res, next) => {
+		const authHeader = req.headers.authorization;
+
+		if (!authHeader || !authHeader.startsWith('Basic ')) {
+			return res.json({
+				ok: false,
+				msg: 'missing authorization header',
+			});
+		}
+
+		const [username, password] = Buffer.from(
+			authHeader.replace('Basic ', ''),
+			'base64'
+		)
+			.toString()
+			.split(':');
+
+		let state = {
+			ok: true,
+			msg: 'successful authenticated',
+		};
+
+		if (!users[username]) {
+			state = {
+				ok: false,
+				msg: 'user not found',
+			};
+		}
+
+		if (
+			requirePassword &&
+			!(await bcrypt.compare(password, users[username].passwordHash))
+		) {
+			state = {
+				ok: false,
+				msg: 'incorrect password',
+			};
+		}
+
+		if (!state.ok) {
+			if (options.callback) await options.callback(req, username, state);
+			return res.json(state);
+		}
+
+		req.user = username;
+		req.stead = users[username].stead;
+
+		if (options.callback) await options.callback(req, username, state);
+
+		next();
+	};
+};
+export default auth;

--- a/identifyProvider.js
+++ b/identifyProvider.js
@@ -1,0 +1,188 @@
+import { Router } from 'express';
+import crypto from 'crypto';
+import { activityPush, DOMAIN, sendWebhook, users } from './main.js';
+import auth from './authentication.js';
+
+// hkgi serves as a iDP (Identity Provider). hkgi allows 3rd party applications
+// to verify the identity of a user. The identity verification process is as
+// follows:
+// 1. 3rd party application POSTs to `/idp/verify/USERNAME` with an optional
+//    `webhookUrl` in the body. The response will be a Verification Request
+// 2. Via the Slack App, the User will recieve a message to verify the
+//    Verification Request. Alternatively, they can also POST to
+//    `/idp/verificationAttemt/ID/verify` with the proper authentication header
+// 3. Once successfuly verified, the 3rd party application will recieve a POST
+//    to the `webhookUrl` (if provided in Step 1). The successful verification
+//    will also appear in the activity feed.
+// 4. (optional) If the 3rd party application did not recieve the webhook, they
+//    can GET `/idp/verificationAttempt/ID` to see if the verification was
+//    successful.
+
+export const router = Router();
+
+// For 3rd party apps to verify the identity of a user.
+router.post('/verify/:username', async (req, res) => {
+	const username = req.params.username;
+	const webhookUrl = req.body.webhookUrl;
+
+	// Check if user exists
+	if (users[username] === undefined) {
+		return res.status(404).json({ ok: false, msg: 'User not found' });
+	}
+
+	// Create Verification Request
+	const id = uniqueId();
+	const url = 'http://' + DOMAIN + '/idp/verificationAttempt/' + id;
+	const verifyUrl = url + '/verify';
+	const verificationRequest = {
+		id,
+		url,
+		verifyUrl,
+		webhookUrl: webhookUrl || null,
+		attempts: [],
+		verifiedAt: null,
+		createdAt: Date.now(),
+	};
+
+	// Save Verification Request to database
+	if (!users[username].verificationRequests)
+		users[username].verificationRequests = {};
+	users[username].verificationRequests[id] = verificationRequest;
+
+	// Remove fields before sending Verification Request in response
+	const vr = Object.assign({}, verificationRequest); // clone
+	delete vr.webhookUrl;
+
+	res.json({ ok: true, verificationAttempt: vr });
+
+	// Add event to activity
+	activityPush('verificationRequest', {
+		id: verificationRequest.id,
+		who: username,
+	});
+});
+
+// For the Slack bot (or user) to verify the Verification Request that was
+// created by a 3rd party application.
+router.post(
+	'/verificationAttempt/:id/verify',
+	auth({
+		callback: (req, username, state) => {
+			// Log failed verification attempts
+			if (state.ok) return;
+
+			const vrId = req.params.id;
+
+			// Check if verification request exists
+			if (users[username]?.verificationRequests?.[vrId] === undefined) return;
+
+			// Check if verification request was already successful, don't log attempt
+			if (users[username].verificationRequests[vrId].verifiedAt) return;
+
+			// Save verification attempt to database
+			const attempt = {
+				verified: false,
+				attemptedAt: Date.now(),
+			};
+			users[username].verificationRequests[vrId].attempts.push(attempt);
+
+			// Add event to activity
+			activityPush('verificationAttempt', {
+				verificationRequestId: vrId,
+				...attempt,
+			});
+		},
+	}),
+	async (req, res) => {
+		const username = req.user;
+		const user = users[username];
+		const id = req.params.id;
+
+		// Check if verification attempt exists
+		if (user.verificationRequests?.[id] === undefined) {
+			return res.status(404).json({
+				ok: false,
+				msg: "You're authentication, but verification attempt was not found",
+			});
+		}
+
+		// Check if verification request was already successful, don't log attempt
+		if (user.verificationRequests[id].verifiedAt) return res.json({ ok: true });
+
+		// Save successful verification request to database
+		const verifiedAt = Date.now();
+		const attempt = {
+			verified: true,
+			attemptedAt: verifiedAt,
+		};
+		user.verificationRequests[req.params.id].verifiedAt = verifiedAt;
+		user.verificationRequests[req.params.id].attempts.push(attempt);
+
+		res.json({ ok: true });
+
+		// Send webhook if provided
+		const webhookUrl = user.verificationRequests[req.params.id].webhookUrl;
+		if (webhookUrl)
+			sendWebhook(webhookUrl, user.verificationRequests[req.params.id]);
+
+		// Add event to activity
+		activityPush('verificationAttempt', {
+			verificationRequestId: id,
+			...attempt,
+		});
+	}
+);
+
+router.get('/verificationAttempt/:id', async (req, res) => {
+	const id = req.params.id;
+
+	// Check if verification attempt exists
+	let va;
+	let user;
+	for (const currUser in users) {
+		if (!users[currUser].verificationRequests) continue;
+		for (const vrid of Object.keys(users[currUser].verificationRequests)) {
+			if (vrid === id) {
+				user = users[currUser];
+				va = users[currUser].verificationRequests[vrid];
+				break;
+			}
+		}
+	}
+	if (va === undefined)
+		return res
+			.status(404)
+			.json({ ok: false, msg: 'Verification request not found' });
+
+	res.json({
+		ok: true,
+		verificationRequest: user.verificationRequests[id],
+	});
+});
+
+// Helper functions
+
+const generateId = () => {
+	return (1e10)
+		.toString()
+		.replace(/[018]/g, (c) =>
+			(
+				c ^
+				(crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
+			).toString(16)
+		);
+};
+export const uniqueId = () => {
+	const existingids = Object.keys(users)
+		.map((u) => users[u].verificationRequests)
+		.filter((va) => va)
+		.flatMap((va) => Object.keys(va));
+
+	for (let i = 0; i < Number.MAX_SAFE_INTEGER; i++) {
+		const id = generateId();
+		if (!existingids.includes(id)) return id;
+	}
+	throw new Error('Ran out of possible unique IDs');
+};
+
+export { router as idpRouter };

--- a/identifyProvider.js
+++ b/identifyProvider.js
@@ -8,13 +8,15 @@ import auth from './authentication.js';
 // follows:
 // 1. 3rd party application POSTs to `/idp/verify/USERNAME` with an optional
 //    `webhookUrl` in the body. The response will be a Verification Request
-// 2. Via the Slack App, the User will recieve a message to verify the
+// 2. Via the Slack App, the User will receive a message to verify the
 //    Verification Request. Alternatively, they can also POST to
-//    `/idp/verificationAttemt/ID/verify` with the proper authentication header
-// 3. Once successfuly verified, the 3rd party application will recieve a POST
+//    `/idp/verificationAttempt/ID/verify` with the proper authentication
+//    header. Users can learn about this event by listening to the Activity
+//    webhook.
+// 3. Once successfuly verified, the 3rd party application will receive a POST
 //    to the `webhookUrl` (if provided in Step 1). The successful verification
 //    will also appear in the activity feed.
-// 4. (optional) If the 3rd party application did not recieve the webhook, they
+// 4. (optional) If the 3rd party application did not receive the webhook, they
 //    can GET `/idp/verificationAttempt/ID` to see if the verification was
 //    successful.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "axios": "^1.1.3",
         "bcrypt": "^5.1.0",
         "cors": "^2.8.5",
+        "dotenv": "^16.0.3",
         "express": "^4.18.2"
       }
     },
@@ -319,6 +320,14 @@
       "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ee-first": {
@@ -1465,6 +1474,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
       "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "axios": "^1.1.3",
     "bcrypt": "^5.1.0",
     "cors": "^2.8.5",
+    "dotenv": "^16.0.3",
     "express": "^4.18.2"
   },
   "nodemonConfig": {


### PR DESCRIPTION
Since hkgi already has an auth system, this will allow 3rd party applications to leverage hkgi's authentication to verify the identity of users. In otherwords, users only need to have one password and 3rd party applications won't know that password! It works similarly to OpenID... i think


With this PR, hkgi serves as a idP (Identity Provider). hkgi allows 3rd party applications to verify the identity of a user. The identity verification process is as follows:
1. 3rd party application POSTs to `/idp/verify/USERNAME` with an optional `webhookUrl` in the body. The response will be a Verification Request.
2. Via the Slack App, the User will receive a message to verify the Verification Request. Alternatively, they can also POST to `/idp/verification/ID/verify` with the proper authentication header. Users can learn about this event by listening to the Activity webhook.
3. Once successfuly verified, the 3rd party application will receive a POST to the `webhookUrl` (if provided in Step 1). The successful verification will also appear in the activity feed.
4. (optional) If the 3rd party application did not receive the webhook, they can GET `/idp/verification/ID` to see if the verification was successful.